### PR TITLE
Don't run benchmark as part of CircleCI build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ jobs:
       - run: docker build docker/ -t benchmarks
       - run: docker tag benchmarks $DOCKER_USERNAME/benchmarks
       - run: docker push $DOCKER_USERNAME/benchmarks
-      - run: docker run -it --rm -v $(pwd):/src benchmarks brainfuck bench
   run:
     machine: true
     steps:


### PR DESCRIPTION
I wonder if this explains why GitHub was able to run these benchmarks faster (its config doesn't have this line) despite being slower on the other benchmark you did. Oh, I misremembered: CircleCI is *already* faster in this case, it was the Earthly checks where GitHub Actions won out.

(Disclaimer: I work for CircleCI.)